### PR TITLE
1Week

### DIFF
--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -60,4 +60,13 @@ public class LikeablePersonController {
 
         return "usr/likeablePerson/list";
     }
+    @GetMapping("/delete/{id}")
+    public String Likedelete(Member member) {
+
+        InstaMember instaMember = rq.getMember().getInstaMember();
+        LikeablePerson like = this.likeablePersonService.getInstaMember();
+        like.delete.getId();
+
+        return "usr/likeablePerson/list";
+    }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -50,4 +50,7 @@ public class LikeablePersonService {
         return likeablePersonRepository.findByFromInstaMemberId(fromInstaMemberId);
 
     }
+
+    public LikeablePerson getInstaMember() {
+    }
 }


### PR DESCRIPTION
배경
현재 호감목록 기능까지 구현되어 있다.

호감목록 페이지에서는 여태까지 본인이 호감을 표시한 상대방의 목록을 볼 수 있다.

현재 삭제버튼까지 구현되어 있다.

목표
호감목록 페이지에서 특정 항목에서 삭제버튼을 누르면, 해당 항목은 삭제되어야 한다.

삭제를 처리하기 전에 해당 항목에 대한 소유권이 본인(로그인한 사람)에게 있는지 체크해야 한다.

삭제 후 다시 호감목록 페이지로 돌아와야 한다.

rq.redirectWithMsg 함수 사용